### PR TITLE
fix(sushi_fabric): preserve false-default params in set_user_parameters back-fill

### DIFF
--- a/master/lib/sushi_fabric/lib/sushi_fabric/sushiApp.rb
+++ b/master/lib/sushi_fabric/lib/sushi_fabric/sushiApp.rb
@@ -371,7 +371,7 @@ class SushiApp
                           end
       end
       (@params.keys - headers).each do |key|
-        unless @params[key]
+        if @params[key].nil?
           @params[key] = @params.default_value(key)
         end
       end

--- a/master/lib/sushi_fabric/spec/sushi_app_spec.rb
+++ b/master/lib/sushi_fabric/spec/sushi_app_spec.rb
@@ -90,5 +90,24 @@ describe SushiApp do
       sushi_app.instance_variable_set(:@dataset, dataset)
     end
     it {is_expected.to be_nil}
-  end 
+  end
+  describe "#set_user_parameters back-fill of omitted params" do
+    # A false-default boolean omitted from the parameterset (declared like CellRangerApp's
+    # runVeloCyto) must keep its `false` default. The back-fill guard used to be a falsy
+    # test, so `false` was treated as "unset" and overwritten with default_value (nil,
+    # since falsy defaults are not recorded) -> empty in parameters.tsv -> NA in R ->
+    # `if(param$runVeloCyto)` crash. (Only `false` is affected; '' and 0 are truthy in Ruby.)
+    subject(:app) {SushiApp.new}
+    before do
+      app.params["runVeloCyto"] = false       # false-default boolean
+      app.params["cores"]       = ["1", "2"]
+      app.instance_variable_set(:@parameterset_tsv_file, true)
+      # parameterset specifies only cores, omitting runVeloCyto:
+      allow(CSV).to receive(:readlines).and_return([["cores", "2"]])
+      app.set_user_parameters
+    end
+    it "keeps a false-default boolean as false (not nil)" do
+      expect(app.params["runVeloCyto"]).to eq false
+    end
+  end
 end


### PR DESCRIPTION
### Problem
When a `parameterset.tsv` omits a parameter, `SushiApp#set_user_parameters` back-fills it from the app default. The guard was a **falsy** test:

```ruby
(@params.keys - headers).each do |key|
  unless @params[key]                  # treats `false` as "unset"
    @params[key] = @params.default_value(key)
  end
end
```

A param whose value is `false` is therefore treated as missing and overwritten with `default_value(key)`. But for a `false`-default param no default was ever recorded — the `::Hash#[]=` monkey-patch only records a default when the value is truthy (`if !@defaults[k1] and k2`). So `default_value` returns `nil`, the param becomes `nil` → written empty into `parameters.tsv` → read as `NA` in R → the app's R wrapper crashes on e.g.:

```
Error in if (param$runVeloCyto) { : missing value where TRUE/FALSE needed
```

This is silent until late: the crash fires only **after** the analysis step has run (observed with `EzAppCellRanger`, after `cellranger count` had already completed ~1 h, producing no registered output). It affects any app with a `false`-default boolean submitted via the `sushi_fabric` CLI when that param is not listed in the parameterset (e.g. `CellRangerApp` `runVeloCyto`/`bamStats`; `FastqcApp`/`STARApp` `paired`, `twopassMode`, `markDuplicates`, ...). The web UI is unaffected, since its checkboxes always submit an explicit `true`/`false`.

### Fix
Back-fill only genuinely-unset (`nil`) params:

```ruby
  if @params[key].nil?
    @params[key] = @params.default_value(key)
  end
```

In Ruby only `nil` and `false` are falsy, so the **only** behavioral change is that an omitted `false` value is now preserved instead of nil'd. `''` and `0` are truthy and were already preserved by the old guard. `nil` params are still back-filled.

### Test
Adds an RSpec example in `spec/sushi_app_spec.rb` (`#set_user_parameters back-fill of omitted params`): a `SushiApp` with `runVeloCyto = false` and a parameterset specifying only `cores` must keep `runVeloCyto == false` (was `nil` before the fix). Red before / green after.

### Notes
- One-line behavioral change; no `version.rb` / `Gemfile.lock` bump (can be done on release).
- Pre-existing, unrelated spec failures on Ruby 3.3 remain (`[..].to_h` TypeError, `eq Fixnum` NameError) — not touched here.
