### PR TITLE
Wire dataset-level DNA BamStats Sushi app

### DIFF
--- a/master/lib/DnaBamStatsApp.rb
+++ b/master/lib/DnaBamStatsApp.rb
@@ -9,81 +9,96 @@ class DnaBamStatsApp < SushiFabric::SushiApp
   def initialize
     super
     @name = 'DNA BamStats'
+    @params['process_mode'] = 'DATASET'
     @analysis_category = 'QC'
-    @description =<<-EOS
-Runs the following tools that check alignment statistics for the DNA applications<br/>
-<a href='http://samstat.sourceforge.net/'>SAMStat</a><br/>
-<a href='http://qualimap.bioinfo.cipf.es/'>QualiMap</a><br/>
-<a href='http://broadinstitute.github.io/picard/command-line-overview.html#CollectGcBiasMetrics'>picard/CollectGcBiasMetrics</a><br/>
-EOS
-    @required_columns = ['Name','BAM']
-    @required_params = ['cores','ram','refBuild','sortedBam']
+    @description = <<-EOS
+Quality control after the alignment of DNA reads with one dataset-level report across all samples.<br/>
+    EOS
+    @required_columns = ['Name', 'BAM', 'BAI', 'refBuild', 'Species', 'Read Count']
+    @required_params = ['name', 'paired']
     @params['cores'] = '8'
     @params['cores', "context"] = "slurm"
-    @params['ram'] = '30'
+    @params['ram'] = '50'
     @params['ram', "context"] = "slurm"
     @params['scratch'] = '100'
     @params['scratch', "context"] = "slurm"
+    @params['paired'] = false
+    @params['paired', "context"] = "DnaBamStats"
+    @params['name'] = 'DNA_BAM_Statistics'
     @params['refBuild'] = ref_selector
     @params['refBuild', "context"] = "referfence genome assembly"
-    @params['sortedBam'] = true
-    @params['sortedBam', "context"] = "DnaBamStats"
-    @modules = ["Dev/R", "Tools/Picard", "QC/Qualimap", "QC/SAMStat", "Tools/samtools", "Dev/jdk/8"]
+    @params['refFeatureFile'] = 'genes.gtf'
+    @params['refFeatureFile', "context"] = "DnaBamStats"
+    @params['pixelDist'] = '2500'
+    @params['pixelDist', "context"] = "DnaBamStats"
+    @params['runQualimap'] = true
+    @params['runQualimap', "context"] = "DnaBamStats"
+    @params['runPicard'] = true
+    @params['runPicard', "context"] = "DnaBamStats"
+    @params['specialOptions'] = ''
+    @params['mail'] = ""
+    # No explicit jdk here: QC/Qualimap loads Dev/jdk/8 and Tools/Picard loads
+    # Dev/jdk/21, so Picard (listed after Qualimap) leaves jdk21 as the ambient
+    # java. Picard needs jdk21; Qualimap tolerates it because the R app sets
+    # JAVA_OPTS to skip its Java-8-only -XX:MaxPermSize flag. Keep QC/Qualimap
+    # before Tools/Picard so the ambient java stays jdk21.
+    @modules = ["Tools/samtools", "QC/Qualimap", "Tools/Picard", "Dev/R"]
+    @inherit_tags = ["Factor", "B-Fabric"]
   end
+
   def next_dataset
-    samstat_link = File.join(@result_dir, "#{@dataset['Name']}.samstat.html")
-    qualimap_link = File.join(@result_dir, "#{@dataset['Name']}", 'qualimapReport.html')
-    picard_link = File.join(@result_dir, "#{@dataset['Name']}.picard.pdf")
-    {'Name'=>@dataset['Name'],
-     'Samstat Result [File]'=>samstat_link,
-     'Qualimap Result [File]'=>File.join(@result_dir, "#{@dataset['Name']}"),
-     'Picard Result [File]'=>picard_link,
-     'Samstat Report [Link]'=>samstat_link,
-     'Qualimap Report [Link]'=>qualimap_link,
-     'Picard Report  [Link]'=>picard_link
-    }
+    report_dir = File.join(@result_dir, @params['name'])
+    {
+      'Name' => @params['name'],
+      'Report [File]' => report_dir,
+      'Html [Link]' => File.join(report_dir, '00index.html'),
+      'Species' => (dataset = @dataset.first and dataset['Species']),
+      'refBuild' => @params['refBuild'],
+      'refFeatureFile' => @params['refFeatureFile']
+    }.merge(extract_columns(@inherit_tags))
   end
+
   def set_default_parameters
     @params['refBuild'] = @dataset[0]['refBuild']
+    if dataset_has_column?('refFeatureFile')
+      @params['refFeatureFile'] = @dataset[0]['refFeatureFile']
+    end
+    if dataset_has_column?('paired')
+      @params['paired'] = @dataset[0]['paired']
+    end
   end
+
   def commands
-    command =<<-EOS
-#echo Display=$DISPLAY
-set -x
-REF=/srv/GT/reference/#{@params['refBuild']}/../../Sequence/WholeGenomeFasta/genome.fa
-BAM_FILE=#{File.join(@gstore_dir, @dataset['BAM'])}
-FN=$(basename $BAM_FILE)
-###samstat
-cp -a $BAM_FILE .
-samstat $FN
-mv {$FN,#{@dataset['Name']}}.samstat.html
-###qualimap
-unset DISPLAY ; qualimap bamqc -bam $FN -c -nt #{@params['cores']} --java-mem-size=#{@params['ram']}G -outdir #{@dataset['Name']} > qualimap.out
-###picard 
-/usr/local/ngseq/packages/Dev/jdk/21/bin/java -Xmx#{@params['ram']}g -jar $Picard_jar CollectGcBiasMetrics OUTPUT=#{@dataset['Name']}.gc.dat SUMMARY_OUTPUT=#{@dataset['Name']}.gc.sum.dat INPUT=$FN CHART_OUTPUT=#{@dataset['Name']}.picard.pdf ASSUME_SORTED=#{@params['sortedBam']} REFERENCE_SEQUENCE=$REF VALIDATION_STRINGENCY=LENIENT > picard.out 2> picard.err
-EOS
-    command
+    run_RApp("EzAppDnaBamStats")
   end
 end
 
 if __FILE__ == $0
-  usecase = DnaBamStats.new
+  usecase = DnaBamStatsApp.new
 
   usecase.project = "p1001"
-  usecase.user = 'qiwei'
+  usecase.user = "masa"
 
   # set user parameter
   # for GUI sushi
-  #usecase.params['process_mode'].value = 'SAMPLE'
-  usecase.params['cores'] = 1
-  usecase.params['node'] = 'fgcz-c-048'
+  # usecase.params['process_mode'].value = 'DATASET'
+  # usecase.params['refBuild'] = 'TAIR10'
+  # usecase.params['paired'] = true
+  # usecase.params['cores'] = 2
+  # usecase.params['node'] = 'fgcz-c-048'
+
+  # also possible to load a parameterset csv file
+  # mainly for CUI sushi
+  usecase.parameterset_tsv_file = 'tophat_parameterset.tsv'
+
+  # set input dataset
+  # mainly for CUI sushi
+  usecase.dataset_tsv_file = 'tophat_dataset.tsv'
 
   # also possible to load a input dataset from Sushi DB
-  usecase.dataset_sushi_id = 1
+  # usecase.dataset_sushi_id = 1
 
   # run (submit to workflow_manager)
-  #usecase.run
-  usecase.test_run
-
+  usecase.run
+  # usecase.test_run
 end
-


### PR DESCRIPTION
DATASET-mode DNA BamStats Sushi app: required columns incl. Read Count;
modules Tools/samtools, QC/Qualimap, Tools/Picard, Dev/R (no explicit jdk —
the tool modules self-load; Picard after Qualimap leaves jdk21 ambient, which
the ezRun app relies on). runQualimap/runPicard toggles; next_dataset exposes
the Report / Html links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
